### PR TITLE
Install Ruby development packages by default

### DIFF
--- a/ansible/group_vars/all.example
+++ b/ansible/group_vars/all.example
@@ -9,7 +9,7 @@ pip_version: 1.0*-1build1
 
 # azavea.ruby
 ruby_version: 2.2
-ruby_development: False
+ruby_development: True
 
 # cartodb.postgresql
 postgresql_version: 9.3


### PR DESCRIPTION
Without the Ruby development packages installed, the Compass gem installation fails. This is because it contains a native extension that makes use of Ruby specific header files.

---

**Testing**

Destroy your local VM and reprovision it from scratch:

``` bash
$ vagrant destroy -f
$ vagrant up
```
