### PR TITLE
Optionally use local account for common datasets.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ ansible/roles/azavea.*
 # Ansible group_vars
 ansible/group_vars/all
 
+# Ansible retry files
+ansible/*.retry

--- a/ansible/group_vars/all.example
+++ b/ansible/group_vars/all.example
@@ -32,6 +32,12 @@ cartodb_user_admin_password: cartodb
 cartodb_user_email: cartodb@example.com
 cartodb_compile_assets: True
 
+# local account for common datasets; set cartodb_common_data_local to True to import to local account
+cartodb_common_data_local: False
+cartodb_common_data_user_email: commondata@example.com
+cartodb_common_data_user_password: cartodb
+cartodb_common_data_user_data_quota: 20.gigabytes
+
 # cartodb app_config.yml
 cartodb_cdn_assets: False
 cartodb_common_data_protocol: 'https'

--- a/ansible/group_vars/all.example
+++ b/ansible/group_vars/all.example
@@ -39,7 +39,9 @@ cartodb_common_data_user_password: cartodb
 cartodb_common_data_user_data_quota: 20.gigabytes
 
 # whether to import common datasets to local account as part of provision
-# (should only be true if cartodb_common_data_local is also true)
+# Enabling this flag uses rake tasks not provided by the CartoDB repository.
+# Also set cartodb_common_base_url to 'http://common-data.localhost.lan:3000' for local data source.
+# This flag should only be true if cartodb_common_data_local is also true.
 cartodb_common_data_import: False
 
 # cartodb app_config.yml

--- a/ansible/group_vars/all.example
+++ b/ansible/group_vars/all.example
@@ -38,6 +38,10 @@ cartodb_common_data_user_email: commondata@example.com
 cartodb_common_data_user_password: cartodb
 cartodb_common_data_user_data_quota: 20.gigabytes
 
+# whether to import common datasets to local account as part of provision
+# (should only be true if cartodb_common_data_local is also true)
+cartodb_common_data_import: False
+
 # cartodb app_config.yml
 cartodb_cdn_assets: False
 cartodb_common_data_protocol: 'https'

--- a/ansible/roles/cartodb.app/tasks/main.yml
+++ b/ansible/roles/cartodb.app/tasks/main.yml
@@ -46,6 +46,7 @@
 
  - name: Remove table limit for common data user
    command: bundle exec rake cartodb:db:remove_table_quota USER_NAME="{{ cartodb_common_data_username }}"
+   become_user: "{{ ansible_ssh_user }}"
    args:
      chdir: "{{ cartodb_dir }}"
    when: cartodb_common_data_local
@@ -69,9 +70,10 @@
    args:
      chdir: "{{ cartodb_dir }}"
    register: import_result
-   when: cartodb_common_data_local
+   when: cartodb_common_data_import
 
  - debug: var=import_result.stdout_lines
+   when: cartodb_common_data_import
 
  - name: Start the CartoDB rails server
    service: name=cartodb_server state=restarted

--- a/ansible/roles/cartodb.app/tasks/main.yml
+++ b/ansible/roles/cartodb.app/tasks/main.yml
@@ -49,7 +49,7 @@
    become_user: "{{ ansible_ssh_user }}"
    args:
      chdir: "{{ cartodb_dir }}"
-   when: cartodb_common_data_local
+   when: cartodb_common_data_import
 
  - name: Add cartodb user subdomain to hosts file
    lineinfile: dest=/etc/hosts line="127.0.0.1 {{ cartodb_user_subdomain }}.{{ cartodb_hostname }}"

--- a/ansible/roles/cartodb.app/tasks/main.yml
+++ b/ansible/roles/cartodb.app/tasks/main.yml
@@ -37,14 +37,41 @@
    args:
      chdir: "{{ cartodb_dir }}"
 
+ - name: Create a common data user
+   command: bundle exec rake cartodb:db:create_user QUOTA_IN_BYTES="{{ cartodb_common_data_user_data_quota }}" SUBDOMAIN="{{ cartodb_common_data_username }}" PASSWORD="{{ cartodb_common_data_user_password }}" EMAIL="{{ cartodb_common_data_user_email }}"
+   become_user: "{{ ansible_ssh_user }}"
+   args:
+     chdir: "{{ cartodb_dir }}"
+   when: cartodb_common_data_local
+
+ - name: Remove table limit for common data user
+   command: bundle exec rake cartodb:db:remove_table_quota USER_NAME="{{ cartodb_common_data_username }}"
+   args:
+     chdir: "{{ cartodb_dir }}"
+   when: cartodb_common_data_local
+
  - name: Add cartodb user subdomain to hosts file
    lineinfile: dest=/etc/hosts line="127.0.0.1 {{ cartodb_user_subdomain }}.{{ cartodb_hostname }}"
+
+ - name: Add common data user subdomain to hosts file
+   lineinfile: dest=/etc/hosts line="127.0.0.1 {{ cartodb_common_data_username }}.{{ cartodb_hostname }}"
+   when: cartodb_common_data_local
 
  - name: Add cartodb hostname to hosts file
    lineinfile: dest=/etc/hosts line="127.0.0.1 {{ cartodb_hostname }}"
 
  - name: Copy rails server job template
    template: src=cartodb_server.conf.j2 dest=/etc/init/cartodb_server.conf
+
+ - name: Import common data to local user
+   command: bundle exec rake cartodb:common_data:import_common_data
+   become_user: "{{ ansible_ssh_user }}"
+   args:
+     chdir: "{{ cartodb_dir }}"
+   register: import_result
+   when: cartodb_common_data_local
+
+ - debug: var=import_result.stdout_lines
 
  - name: Start the CartoDB rails server
    service: name=cartodb_server state=restarted

--- a/ansible/roles/cartodb.app/templates/app_config.yml.j2
+++ b/ansible/roles/cartodb.app/templates/app_config.yml.j2
@@ -103,7 +103,7 @@ defaults: &defaults
   common_data:
     protocol: '{{ cartodb_common_data_protocol }}'
     username: '{{ cartodb_common_data_username }}'
-    base_url: '{{ cartodb_common_data_base_url }}'
+{% if not cartodb_common_data_local %}    base_url: '{{ cartodb_common_data_base_url }}'{% endif %}
     format: '{{ cartodb_common_data_format }}'
     generate_every: {{ cartodb_common_data_generate_every }}
   explore_api:


### PR DESCRIPTION
Import common datasets from CartoDB to local account during provisioning.
