### PR TITLE
Add nginx configuration for CartoDB vagrant box

### DIFF
--- a/ansible/roles.txt
+++ b/ansible/roles.txt
@@ -1,4 +1,5 @@
 azavea.git,0.1.0
+azavea.nginx,0.2.1
 azavea.python,0.1.0
 azavea.pip,0.1.1
 azavea.ruby,0.3.0

--- a/ansible/roles/cartodb.app/defaults/main.yml
+++ b/ansible/roles/cartodb.app/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+cartodb_http_port: 80

--- a/ansible/roles/cartodb.app/meta/main.yml
+++ b/ansible/roles/cartodb.app/meta/main.yml
@@ -2,3 +2,4 @@
 
 dependencies:
  - { role: "cartodb.app.dependencies" }
+ - { role: "cartodb.nginx" }

--- a/ansible/roles/cartodb.app/templates/app_config.yml.j2
+++ b/ansible/roles/cartodb.app/templates/app_config.yml.j2
@@ -11,11 +11,11 @@ defaults: &defaults
   session_domain:     '.localhost.lan'
   # If activated, urls will use usernames in format //SESSION_DOMAIN/user/USERNAME and ignore subdomains if present
   subdomainless_urls: false
-  http_port:           3000 # nil|integer. HTTP port to use when building urls. Leave empty to use default (80)
+  http_port:           {{ cartodb_http_port }} # nil|integer. HTTP port to use when building urls. Leave empty to use default (80)
   https_port:          # nil|integer. HTTPS port to use when building urls. Leave empty to use default (443)
   maps_api_cdn_template: # nil|string. E.g. '{protocol}://{zone}.cartocdn/{user}' (`/api/v1/...` fragment added via code)
   secret_token:       '71c2b25921b84a1cb21c71503ab8fb23'
-  account_host:       'localhost.lan:3000'
+  account_host:       'localhost.lan:{{ cartodb_http_port }}'
   account_path:       '/account'
   disable_file:       '~/disable'
   watcher:
@@ -50,7 +50,7 @@ defaults: &defaults
       endpoint:   '/api/v2/sql'
       port:       8080
   api_requests_service_url: ''
-  developers_host:    'http://developers.localhost.lan:3000'
+  developers_host:    'http://developers.localhost.lan:{{ cartodb_http_port }}'
   google_analytics:
     primary:          ''
     embeds:           ''
@@ -146,7 +146,7 @@ defaults: &defaults
       redis_migrator_logs: 6
   org_metadata_api:
     host: 'localhost.lan'
-    port: '3000'
+    port: '{{ cartodb_http_port }}'
     username: "extension"
     password: "elephant"
     timeout: 10
@@ -449,7 +449,6 @@ defaults: &defaults
 
 development:
   <<: *defaults
-  http_port: 3000
   varnish_management:
     critical: false
     host: '127.0.0.1'

--- a/ansible/roles/cartodb.nginx/defaults/main.yml
+++ b/ansible/roles/cartodb.nginx/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+
+nginx_sites_available:
+  - "cartodb"
+
+nginx_sites_enabled:
+  - "cartodb"

--- a/ansible/roles/cartodb.nginx/meta/main.yml
+++ b/ansible/roles/cartodb.nginx/meta/main.yml
@@ -1,0 +1,4 @@
+---
+
+dependencies:
+ - { role: "azavea.nginx", nginx_delete_default_site: True }

--- a/ansible/roles/cartodb.nginx/tasks/main.yml
+++ b/ansible/roles/cartodb.nginx/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+
+  - name: Copy nginx sites-available
+    template: src='nginx-site.{{ item }}.conf.j2' dest='/etc/nginx/sites-available/{{ item }}.conf'
+    with_items: nginx_sites_available
+
+  - name: Symlink requested sites-available to sites-enabled
+    file: path='/etc/nginx/sites-enabled/{{ item }}.conf' src='/etc/nginx/sites-available/{{ item }}.conf' state=link
+    with_items: nginx_sites_enabled
+    when: nginx_sites_enabled is defined
+
+  - name: Restart nginx
+    service: name=nginx state=restarted

--- a/ansible/roles/cartodb.nginx/templates/nginx-site.cartodb.conf.j2
+++ b/ansible/roles/cartodb.nginx/templates/nginx-site.cartodb.conf.j2
@@ -1,0 +1,83 @@
+server {
+  listen 80;
+
+  client_max_body_size 500m;
+  server_name _;
+  keepalive_timeout 30;
+  root {{ cartodb_dir }}/public;
+  try_files $uri/index.html $uri.html $uri @cartodb;
+
+  location @cartodb {
+      proxy_pass http://localhost:3000;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;
+      proxy_redirect off;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Sendfile-Type X-Accel-Redirect;
+  }
+  location /tiles {
+      proxy_pass http://localhost:8181;
+      proxy_redirect off;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      # SSL: Pass on SSL if necessary
+      #proxy_set_header X-Forwarded-Proto $scheme;
+  }
+  location /api/v1/maps {
+      proxy_pass http://localhost:3000;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;
+      proxy_redirect off;
+      proxy_set_header X-Forwarded-Proto $scheme;
+  }
+  # Cannot be an exact match or things are not routed correctly, the previous block catches /maps
+  # this one forwards requests to the windshaft server
+  location /api/v1/map {
+      proxy_pass http://localhost:8181/api/v1/map;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      # SSL: Pass on SSL if necessary
+      #proxy_set_header X-Forwarded-Proto $scheme;
+  }
+  location /api/v1/sql {
+      proxy_pass http://localhost:8080;
+      proxy_redirect off;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Access-Control-Allow-Origin *;
+      proxy_set_header Access-Control-Allow-Headers 'X-Requested-With,X-Prototype-Version,X-CSRF-Token';
+      # SSL: Pass on SSL if necessary
+      #proxy_set_header X-Forwarded-Proto $scheme;
+  }
+  location /api/v2/sql {
+      proxy_pass http://localhost:8080;
+      proxy_redirect off;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Access-Control-Allow-Origin *;
+      proxy_set_header Access-Control-Allow-Headers 'X-Requested-With,X-Prototype-Version,X-CSRF-Token';
+      # SSL: Pass on SSL if necessary
+      #proxy_set_header X-Forwarded-Proto $scheme;
+  }
+  # This is the endpoint that cartodb.js uses for requesting visualization tiles
+  location /tilecache/ {
+      rewrite ^/tilecache/(.*)/api/v1/map/(.*) http://$1.$server_name/tiles/layergroup/$2;
+  }
+  error_page 403 /403.html;
+  location = /403.html {
+    root {{ cartodb_dir }}/public;
+    allow all;
+  }
+  error_page 404 /404.html;
+  location = /404.html {
+    root {{ cartodb_dir }}/public;
+  }
+  error_page 500 502 503 504 /500.html;
+  location = /500.html {
+    root {{ cartodb_dir }}/public;
+  }
+}


### PR DESCRIPTION
This change uses nginx to serve the application on port 80
Application is now accessed at http://development.localhost.lan
- Allows local common data imports to succeed, since those
  are hardcoded to use port 80
- Better mirrors a production environment

Nginx can be bypassed by adding the line:

```
cartodb_http_port: 3000
```

in your `ansible/group_vars/all` file and reprovisioning
