### PR TITLE
Provision foreign data wrapper setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,15 @@ If you would like to use a different tag of the cartodb repo, be sure to change 
 versions of the sql api and windshaft in `ansible/group_vars/all`
 
 Ensure you reprovision after making any changes to the ansible settings.
+
+
+## Troubleshooting
+
+#### Data Library doesn't load on the dashboard
+
+If for some reason after provision, the data library in the development account does not load
+when you first navigate to your dashboard, try executing:
+```
+cd /opt/cartodb && bundle exec rake cartodb:remotes:reload['development']
+```
+inside the VM. Then navigate back to your dashboard once the rake task completes.

--- a/README.md
+++ b/README.md
@@ -45,9 +45,20 @@ cp ansible/group_vars/all.example ansible/group_vars/all
 Add the following entries in your hosts file to point to the VM:
 ```
 192.168.20.100 development.localhost.lan
-192.168.20.100 test.localhost.lan
 192.168.20.100 commondata.localhost.lan
 192.168.20.100 localhost.lan
+```
+
+If planning on using the organization account, you'll also need to add the following to your
+hosts file:
+```
+192.168.20.100 test.localhost.lan
+192.168.20.100 test-admin.localhost.lan
+192.168.20.100 test-1.localhost.lan
+192.168.20.100 test-2.localhost.lan
+192.168.20.100 test-3.localhost.lan
+192.168.20.100 test-4.localhost.lan
+192.168.20.100 test-5.localhost.lan
 ```
 
 ## Using the VM

--- a/README.md
+++ b/README.md
@@ -45,22 +45,28 @@ cp ansible/group_vars/all.example ansible/group_vars/all
 Add the following entries in your hosts file to point to the VM:
 ```
 192.168.20.100 development.localhost.lan
+192.168.20.100 test.localhost.lan
+192.168.20.100 commondata.localhost.lan
 192.168.20.100 localhost.lan
 ```
 
 ## Using the VM
 
-Run `vagrant up`, wait for the machine to provision, then navigate to http://development.localhost.lan:3000/login
+Run `vagrant up`, wait for the machine to provision, then navigate to http://development.localhost.lan/login
 and login with:
  - Username: development
  - Password: cartodb
+
+ Alternatively, if `cartodb_add_org_account: true` in ansible settings, you can navigate to http://test.localhost.lan/login
+ and login with usernames `test-admin, test-1, test-2, test-3, test-4, test-5` where the password for each account
+ is the same as the username.
 
 #### Services in the VM
 
 The cartodb services (unicorn, resque, sql api, windshaft) are controlled via upstart. The service
 names are:
 - `cartodb_server` - Unicorn web worker processes
-- `cartodb_resque_worker` - A single resque worker process (the VM runs two)
+- `cartodb_resque_worker` - A single resque worker process (the VM runs one but it can be configured via `cartodb_resque_workers` ansible setting)
 - `cartodb_windshaft` - Windshaft server
 - `cartodb_sqlapi` - CartoDB SQL API server
 

--- a/ansible/group_vars/all.cartodb-org.example
+++ b/ansible/group_vars/all.cartodb-org.example
@@ -1,0 +1,79 @@
+root_dir: /opt
+cartodb_dir: "{{ root_dir }}/cartodb"
+vm_private_ip: 192.168.20.100
+
+# azavea.python
+python_version: 2.7.3-0ubuntu2.2
+python_development: True
+
+# azavea.pip
+pip_version: 1.0*-1build1
+
+# azavea.ruby
+ruby_version: 2.2
+ruby_development: True
+
+
+# cartodb.postgresql
+postgresql_version: 9.5
+postgresql_port: 5432
+postgresql_listen_addresses: 'localhost,{{ vm_private_ip }}'
+postgresql_hba_mapping:
+  - { type: "local", database: "all", user: "all", address: "", method: "trust" }
+  - { type: "local", database: "all", user: "postgres", address: "", method: "trust" }
+  - { type: "host", database: "all", user: "all", address: "127.0.0.1/32", method: "trust" }
+  - { type: "host", database: "all", user: "fdwuser", address: "{{ vm_private_ip }}/32", method: "md5" }
+cartodb_postgresql_dir: "{{ cartodb_dir }}/lib/sql"
+
+# cartodb.app
+# TODO: Support other RAILS_ENV configurations (staging|production)
+# TODO: Properly template cartodb_hostname into app_config and database config
+cartodb_environment: development
+cartodb_hostname: localhost.lan
+cartodb_user_subdomain: development
+cartodb_user_password: cartodb
+cartodb_user_admin_password: cartodb
+cartodb_user_email: cartodb@example.com
+cartodb_compile_assets: True
+
+# local account for common datasets; set cartodb_common_data_local to True to import to local account
+cartodb_common_data_local: True
+cartodb_common_data_user_email: commondata@example.com
+cartodb_common_data_user_password: cartodb
+cartodb_common_data_user_data_quota: 20.gigabytes
+
+# whether to import common datasets to local account as part of provision
+# Enabling this flag uses rake tasks not provided by the CartoDB repository.
+# Also set cartodb_common_base_url to 'http://commondata.localhost.lan' for local data source.
+# This flag should only be true if cartodb_common_data_local is also true.
+cartodb_common_data_import: True
+
+# cartodb app_config.yml
+cartodb_cdn_assets: False
+cartodb_common_data_protocol: 'http'
+cartodb_common_data_username: 'commondata'
+cartodb_common_data_base_url: 'http://commondata.localhost.lan'
+cartodb_common_data_format: 'shp'
+cartodb_common_data_generate_every: 86400
+cartodb_common_data_api_key: ''
+# If configuring fdw, you'll need to set cartodb_fdw_database after first provision
+# If you don't have an external server, you'll need to set it to the database name of the
+# commondata user that gets created above
+cartodb_fdw_host: '{{ vm_private_ip }}'
+cartodb_fdw_port: 5432
+cartodb_fdw_database: ''
+cartodb_fdw_username: 'fdwuser'
+cartodb_fdw_password: 'cartodb_fdw'
+cartodb_fdw_remote_schema: '{{ cartodb_common_data_username }}'
+
+cartodb_add_org_account: True
+
+# cartodb.sqlapi
+cartodb_sqlapi_dir: "{{ root_dir }}/cartodb_sql_api"
+cartodb_sqlapi_version: 1.27.0
+cartodb_sqlapi_host: 0.0.0.0
+
+# cartodb.windshaft
+cartodb_windshaft_dir: "{{ root_dir }}/cartodb_windshaft"
+cartodb_windshaft_version: 2.31.2
+cartodb_windshaft_host: 0.0.0.0

--- a/ansible/group_vars/all.example
+++ b/ansible/group_vars/all.example
@@ -37,6 +37,7 @@ cartodb_common_data_local: False
 cartodb_common_data_user_email: commondata@example.com
 cartodb_common_data_user_password: cartodb
 cartodb_common_data_user_data_quota: 20.gigabytes
+cartodb_common_data_api_key: ''
 # If configuring fdw, you'll need to set cartodb_fdw_database after first provision
 # If you don't have an external server, you'll need to set it to the database name of the
 # commondata user that gets created above
@@ -60,6 +61,8 @@ cartodb_common_data_username: 'common-data'
 cartodb_common_data_base_url: 'https://common-data.cartodb.com'
 cartodb_common_data_format: 'shp'
 cartodb_common_data_generate_every: 86400
+
+cartodb_add_org_account: True
 
 # cartodb.sqlapi
 cartodb_sqlapi_dir: "{{ root_dir }}/cartodb_sql_api"

--- a/ansible/roles/cartodb.app/defaults/main.yml
+++ b/ansible/roles/cartodb.app/defaults/main.yml
@@ -2,9 +2,13 @@
 
 cartodb_http_port: 80
 
+cartodb_common_data_api_key: ''
+
 cartodb_fdw_host: ''
 cartodb_fdw_port: 5432
 cartodb_fdw_database: ''
 cartodb_fdw_username: 'fdwuser'
 cartodb_fdw_password: 'cartodb_fdw'
 cartodb_fdw_remote_schema: 'public'
+
+cartodb_add_org_account: False

--- a/ansible/roles/cartodb.app/tasks/add_org_account.yml
+++ b/ansible/roles/cartodb.app/tasks/add_org_account.yml
@@ -1,0 +1,14 @@
+---
+
+ - name: Add org test account
+   command: bundle exec rake cartodb:db:create_test_organization['test','5']
+   become_user: "{{ ansible_ssh_user }}"
+   register: create_org_result
+   failed_when: "create_org_result.stderr != '' and 'name is already taken' not in create_org_result.stderr"
+   args:
+     chdir: "{{ cartodb_dir }}"
+   when: cartodb_add_org_account
+
+ - name: Add test org user subdomain to hosts file
+   lineinfile: dest=/etc/hosts line="127.0.0.1 test.{{ cartodb_hostname }}"
+   when: cartodb_add_org_account

--- a/ansible/roles/cartodb.app/tasks/main.yml
+++ b/ansible/roles/cartodb.app/tasks/main.yml
@@ -82,5 +82,23 @@
  - debug: var=import_result.stdout_lines
    when: cartodb_common_data_import
 
+ - name: Clear common data for development user
+   command: bundle exec rake cartodb:remotes:clear['{{ cartodb_user_subdomain }}']
+   become_user: "{{ ansible_ssh_user }}"
+   args:
+     chdir: "{{ cartodb_dir }}"
+   when: cartodb_common_data_import
+
+ - name: Reload common data for development user
+   command: bundle exec rake cartodb:remotes:reload['{{ cartodb_user_subdomain }}']
+   become_user: "{{ ansible_ssh_user }}"
+   args:
+     chdir: "{{ cartodb_dir }}"
+   when: cartodb_common_data_import
+
+ - include: setup_fdw.yml
+
+ - include: add_org_account.yml
+
  - name: Start the CartoDB rails server
    service: name=cartodb_server state=restarted

--- a/ansible/roles/cartodb.app/tasks/main.yml
+++ b/ansible/roles/cartodb.app/tasks/main.yml
@@ -7,6 +7,10 @@
      chdir: "{{ cartodb_dir }}"
    when: cartodb_compile_assets
 
+ - name: Ensure cartodb log dir exists
+   file: path="{{ cartodb_dir }}/log" state=directory
+   become_user: "{{ ansible_ssh_user }}"
+
  - name: Touch app_config.yml to ensure it exists
    file: path="{{ cartodb_dir }}/config/app_config.yml" state=touch
 

--- a/ansible/roles/cartodb.app/tasks/main.yml
+++ b/ansible/roles/cartodb.app/tasks/main.yml
@@ -44,6 +44,13 @@
      chdir: "{{ cartodb_dir }}"
    when: cartodb_common_data_local
 
+ - name: Move common data user to its own schema
+   command: bundle exec rake cartodb:db:move_user_to_schema['{{ cartodb_common_data_username }}']
+   become_user: "{{ ansible_ssh_user }}"
+   args:
+     chdir: "{{ cartodb_dir }}"
+   when: cartodb_common_data_local
+
  - name: Remove table limit for common data user
    command: bundle exec rake cartodb:db:remove_table_quota USER_NAME="{{ cartodb_common_data_username }}"
    become_user: "{{ ansible_ssh_user }}"

--- a/ansible/roles/cartodb.app/tasks/setup_fdw.yml
+++ b/ansible/roles/cartodb.app/tasks/setup_fdw.yml
@@ -1,0 +1,39 @@
+---
+
+ - name: Get commondata database name
+   command: psql -d carto_db_development -t -c "select database_name from users where username='{{ cartodb_common_data_username }}'"
+   become_user: postgres
+   register: cartodb_fdw_database_result
+   when: cartodb_common_data_local
+
+ - name: Get commondata user id
+   command: psql -d carto_db_development -t -c "select id from users where username='{{ cartodb_common_data_username }}'"
+   become_user: postgres
+   register: cartodb_common_data_user_id_result
+   when: cartodb_common_data_local
+
+ - name: Get commondata API key
+   command: psql -d carto_db_development -t -c "select api_key from users where username='{{ cartodb_common_data_username }}'"
+   become_user: postgres
+   register: cartodb_common_data_api_key_result
+   when: cartodb_common_data_local
+
+ - name: Set local variables needed for further tasks
+   set_fact:
+     cartodb_fdw_database: "{{ cartodb_fdw_database_result.stdout.strip() }}"
+     cartodb_common_data_user_id: "{{ cartodb_common_data_user_id_result.stdout.strip() }}"
+     cartodb_common_data_api_key: "{{ cartodb_common_data_api_key_result.stdout.strip() }}"
+   when: cartodb_common_data_local
+
+ - name: Add a foreign data wrapper user to the commondata database
+   postgresql_user: db="{{ cartodb_fdw_database }}" user="{{ cartodb_fdw_username }}" encrypted=yes password="{{ cartodb_fdw_password }}"
+   when: cartodb_common_data_local
+
+ - name: Add foreign data wrapper user to commondata database cartodb user role
+   command: psql -d "{{ cartodb_fdw_database }}" -c "GRANT \"development_cartodb_user_{{ cartodb_common_data_user_id }}\" TO fdwuser"
+   become_user: postgres
+   when: cartodb_common_data_local
+
+ - name: Reload app_config.yml template with new settings (commondata api key, fdw user database)
+   template: src=app_config.yml.j2 dest="{{ cartodb_dir }}/config/app_config.yml"
+   when: cartodb_common_data_local

--- a/ansible/roles/cartodb.app/templates/app_config.yml.j2
+++ b/ansible/roles/cartodb.app/templates/app_config.yml.j2
@@ -108,6 +108,7 @@ defaults: &defaults
 {% endif %}
     format: '{{ cartodb_common_data_format }}'
     generate_every: {{ cartodb_common_data_generate_every }}
+    api_key: '{{ cartodb_common_data_api_key }}'
   fdw:
     host: '{{ cartodb_fdw_host }}'
     port: {{ cartodb_fdw_port }}

--- a/ansible/roles/cartodb.app/templates/app_config.yml.j2
+++ b/ansible/roles/cartodb.app/templates/app_config.yml.j2
@@ -103,7 +103,7 @@ defaults: &defaults
   common_data:
     protocol: '{{ cartodb_common_data_protocol }}'
     username: '{{ cartodb_common_data_username }}'
-{% if not cartodb_common_data_local %}
+{% if cartodb_common_data_base_url %}
     base_url: '{{ cartodb_common_data_base_url }}'
 {% endif %}
     format: '{{ cartodb_common_data_format }}'

--- a/ansible/roles/cartodb.app/templates/database.yml.j2
+++ b/ansible/roles/cartodb.app/templates/database.yml.j2
@@ -29,7 +29,11 @@ development:
   database: carto_db_development
   username: postgres
   password:
+{% if cartodb_add_org_account %}
+  conn_validator_timeout: -1
+{% else %}
   conn_validator_timeout: 900
+{% endif %}
   pool: 50
 
 test:

--- a/ansible/roles/cartodb.nginx/tasks/main.yml
+++ b/ansible/roles/cartodb.nginx/tasks/main.yml
@@ -2,11 +2,11 @@
 
   - name: Copy nginx sites-available
     template: src='nginx-site.{{ item }}.conf.j2' dest='/etc/nginx/sites-available/{{ item }}.conf'
-    with_items: nginx_sites_available
+    with_items: "{{ nginx_sites_available }}"
 
   - name: Symlink requested sites-available to sites-enabled
     file: path='/etc/nginx/sites-enabled/{{ item }}.conf' src='/etc/nginx/sites-available/{{ item }}.conf' state=link
-    with_items: nginx_sites_enabled
+    with_items: "{{ nginx_sites_enabled }}"
     when: nginx_sites_enabled is defined
 
   - name: Restart nginx

--- a/ansible/roles/cartodb.postgresql/defaults/main.yml
+++ b/ansible/roles/cartodb.postgresql/defaults/main.yml
@@ -5,6 +5,6 @@ postgresql_data_directory: /var/lib/postgresql/{{ postgresql_version }}/main
 postgresql_max_connections: 100
 postgresql_shared_buffers: "128MB"
 postgresql_work_mem: "4MB"
-postgresql_log_autovacuum_min_duration: -1
-postgresql_log_min_duration_statement: -1
+postgresql_log_autovacuum_min_duration: 500
+postgresql_log_min_duration_statement: 500
 postgresql_hba_mapping: []

--- a/ansible/roles/cartodb.postgresql/defaults/main.yml
+++ b/ansible/roles/cartodb.postgresql/defaults/main.yml
@@ -1,0 +1,10 @@
+postgresql_version: 9.5
+postgresql_listen_addresses: localhost
+postgresql_port: 5432
+postgresql_data_directory: /var/lib/postgresql/{{ postgresql_version }}/main
+postgresql_max_connections: 100
+postgresql_shared_buffers: "128MB"
+postgresql_work_mem: "4MB"
+postgresql_log_autovacuum_min_duration: -1
+postgresql_log_min_duration_statement: -1
+postgresql_hba_mapping: []

--- a/ansible/roles/cartodb.postgresql/tasks/main.yml
+++ b/ansible/roles/cartodb.postgresql/tasks/main.yml
@@ -23,6 +23,9 @@
  - name: Configure PostgreSQL host-based authentication
    template: src=pg_hba.conf.j2 dest=/etc/postgresql/{{ postgresql_version }}/main/pg_hba.conf
 
+ - name: Configure PostgreSQL conf
+   template: src=postgresql.conf.j2 dest=/etc/postgresql/{{ postgresql_version }}/main/postgresql.conf
+
  # Need to force a restart now so that auth settings take effect for all future tasks
  #   Otherwise, things like `bundle exec rake db:create` will hang asking for a password
  # Ansible docs say that 'These notify actions are triggered at the end of each block of tasks

--- a/ansible/roles/cartodb.postgresql/tasks/main.yml
+++ b/ansible/roles/cartodb.postgresql/tasks/main.yml
@@ -22,18 +22,17 @@
 
  - name: Configure PostgreSQL host-based authentication
    template: src=pg_hba.conf.j2 dest=/etc/postgresql/{{ postgresql_version }}/main/pg_hba.conf
+   notify:
+     - Restart PostgreSQL
 
  - name: Configure PostgreSQL conf
    template: src=postgresql.conf.j2 dest=/etc/postgresql/{{ postgresql_version }}/main/postgresql.conf
+   notify:
+     - Restart PostgreSQL
 
  # Need to force a restart now so that auth settings take effect for all future tasks
  #   Otherwise, things like `bundle exec rake db:create` will hang asking for a password
- # Ansible docs say that 'These notify actions are triggered at the end of each block of tasks
- #   in a playbook', which seems like they would trigger at the end of the cartodb.postgresql role,
- #   but they don't seem to trigger until at the very end of provisioning, which is too late
- #   for this particular handler.
- - name: Restart PostgreSQL
-   service: name=postgresql state=restarted
+ - meta: flush_handlers
 
  - name: Add cartodb publicuser
    postgresql_user: name=publicuser port={{ postgresql_port }} state=present role_attr_flags=NOCREATEROLE,NOSUPERUSER,NOCREATEDB

--- a/ansible/roles/cartodb.postgresql/templates/postgresql.conf.j2
+++ b/ansible/roles/cartodb.postgresql/templates/postgresql.conf.j2
@@ -1,0 +1,618 @@
+# -----------------------------
+# PostgreSQL configuration file
+# -----------------------------
+#
+# This file consists of lines of the form:
+#
+#   name = value
+#
+# (The "=" is optional.)  Whitespace may be used.  Comments are introduced with
+# "#" anywhere on a line.  The complete list of parameter names and allowed
+# values can be found in the PostgreSQL documentation.
+#
+# The commented-out settings shown in this file represent the default values.
+# Re-commenting a setting is NOT sufficient to revert it to the default value;
+# you need to reload the server.
+#
+# This file is read on server startup and when the server receives a SIGHUP
+# signal.  If you edit the file on a running system, you have to SIGHUP the
+# server for the changes to take effect, or use "pg_ctl reload".  Some
+# parameters, which are marked below, require a server shutdown and restart to
+# take effect.
+#
+# Any parameter can also be given as a command-line option to the server, e.g.,
+# "postgres -c log_connections=on".  Some parameters can be changed at run time
+# with the "SET" SQL command.
+#
+# Memory units:  kB = kilobytes        Time units:  ms  = milliseconds
+#                MB = megabytes                     s   = seconds
+#                GB = gigabytes                     min = minutes
+#                TB = terabytes                     h   = hours
+#                                                   d   = days
+
+
+#------------------------------------------------------------------------------
+# FILE LOCATIONS
+#------------------------------------------------------------------------------
+
+# The default values of these variables are driven from the -D command-line
+# option or PGDATA environment variable, represented here as ConfigDir.
+
+data_directory = '{{ postgresql_data_directory }}'  # use data in another directory
+                    # (change requires restart)
+hba_file = '/etc/postgresql/{{ postgresql_version }}/main/pg_hba.conf'  # host-based authentication file
+                    # (change requires restart)
+ident_file = '/etc/postgresql/{{ postgresql_version }}/main/pg_ident.conf'  # ident configuration file
+                    # (change requires restart)
+
+# If external_pid_file is not explicitly set, no extra PID file is written.
+external_pid_file = '/var/run/postgresql/{{ postgresql_version }}-main.pid'         # write an extra PID file
+                    # (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# CONNECTIONS AND AUTHENTICATION
+#------------------------------------------------------------------------------
+
+# - Connection Settings -
+
+listen_addresses = '{{ postgresql_listen_addresses }}'
+                    # what IP address(es) to listen on;
+                    # comma-separated list of addresses;
+                    # defaults to 'localhost'; use '*' for all
+                    # (change requires restart)
+port = {{ postgresql_port }}    # (change requires restart)
+max_connections = {{ postgresql_max_connections }}          # (change requires restart)
+# Note:  Increasing max_connections costs ~400 bytes of shared memory per
+# connection slot, plus lock space (see max_locks_per_transaction).
+#superuser_reserved_connections = 3 # (change requires restart)
+unix_socket_directories = '/var/run/postgresql' # comma-separated list of directories
+                    # (change requires restart)
+#unix_socket_group = ''         # (change requires restart)
+#unix_socket_permissions = 0777     # begin with 0 to use octal notation
+                    # (change requires restart)
+#bonjour = off              # advertise server via Bonjour
+                    # (change requires restart)
+#bonjour_name = ''          # defaults to the computer name
+                    # (change requires restart)
+
+# - Security and Authentication -
+
+#authentication_timeout = 1min      # 1s-600s
+ssl = true              # (change requires restart)
+#ssl_ciphers = 'HIGH:MEDIUM:+3DES:!aNULL' # allowed SSL ciphers
+                    # (change requires restart)
+#ssl_prefer_server_ciphers = on     # (change requires restart)
+#ssl_ecdh_curve = 'prime256v1'      # (change requires restart)
+#ssl_renegotiation_limit = 512MB    # amount of data between renegotiations
+ssl_cert_file = '/etc/ssl/certs/ssl-cert-snakeoil.pem'      # (change requires restart)
+ssl_key_file = '/etc/ssl/private/ssl-cert-snakeoil.key'     # (change requires restart)
+#ssl_ca_file = ''           # (change requires restart)
+#ssl_crl_file = ''          # (change requires restart)
+#password_encryption = on
+#db_user_namespace = off
+
+# GSSAPI using Kerberos
+#krb_server_keyfile = ''
+#krb_caseins_users = off
+
+# - TCP Keepalives -
+# see "man 7 tcp" for details
+
+#tcp_keepalives_idle = 0        # TCP_KEEPIDLE, in seconds;
+                    # 0 selects the system default
+#tcp_keepalives_interval = 0        # TCP_KEEPINTVL, in seconds;
+                    # 0 selects the system default
+#tcp_keepalives_count = 0       # TCP_KEEPCNT;
+                    # 0 selects the system default
+
+
+#------------------------------------------------------------------------------
+# RESOURCE USAGE (except WAL)
+#------------------------------------------------------------------------------
+
+# - Memory -
+
+shared_buffers = {{ postgresql_shared_buffers }}            # min 128kB
+                    # (change requires restart)
+#huge_pages = try           # on, off, or try
+                    # (change requires restart)
+#temp_buffers = 8MB         # min 800kB
+#max_prepared_transactions = 0      # zero disables the feature
+                    # (change requires restart)
+# Note:  Increasing max_prepared_transactions costs ~600 bytes of shared memory
+# per transaction slot, plus lock space (see max_locks_per_transaction).
+# It is not advisable to set max_prepared_transactions nonzero unless you
+# actively intend to use prepared transactions.
+work_mem = {{ postgresql_work_mem }}                # min 64kB
+#maintenance_work_mem = 64MB        # min 1MB
+#autovacuum_work_mem = -1       # min 1MB, or -1 to use maintenance_work_mem
+#max_stack_depth = 2MB          # min 100kB
+{% if postgresql_version | version_compare('9.3', '>') %}
+dynamic_shared_memory_type = posix  # the default is the first option
+                    # supported by the operating system:
+                    #   posix
+                    #   sysv
+                    #   windows
+                    #   mmap
+                    # use none to disable dynamic shared memory
+{% endif %}
+
+# - Disk -
+
+#temp_file_limit = -1           # limits per-session temp file space
+                    # in kB, or -1 for no limit
+
+# - Kernel Resource Usage -
+
+#max_files_per_process = 1000       # min 25
+                    # (change requires restart)
+#shared_preload_libraries = ''      # (change requires restart)
+
+# - Cost-Based Vacuum Delay -
+
+#vacuum_cost_delay = 0          # 0-100 milliseconds
+#vacuum_cost_page_hit = 1       # 0-10000 credits
+#vacuum_cost_page_miss = 10     # 0-10000 credits
+#vacuum_cost_page_dirty = 20        # 0-10000 credits
+#vacuum_cost_limit = 200        # 1-10000 credits
+
+# - Background Writer -
+
+#bgwriter_delay = 200ms         # 10-10000ms between rounds
+#bgwriter_lru_maxpages = 100        # 0-1000 max buffers written/round
+#bgwriter_lru_multiplier = 2.0      # 0-10.0 multipler on buffers scanned/round
+
+# - Asynchronous Behavior -
+
+#effective_io_concurrency = 1       # 1-1000; 0 disables prefetching
+#max_worker_processes = 8
+
+
+#------------------------------------------------------------------------------
+# WRITE AHEAD LOG
+#------------------------------------------------------------------------------
+
+# - Settings -
+
+#wal_level = minimal            # minimal, archive, hot_standby, or logical
+                    # (change requires restart)
+#fsync = on             # turns forced synchronization on or off
+#synchronous_commit = on        # synchronization level;
+                    # off, local, remote_write, or on
+#wal_sync_method = fsync        # the default is the first option
+                    # supported by the operating system:
+                    #   open_datasync
+                    #   fdatasync (default on Linux)
+                    #   fsync
+                    #   fsync_writethrough
+                    #   open_sync
+#full_page_writes = on          # recover from partial page writes
+#wal_log_hints = off            # also do full page writes of non-critical updates
+                    # (change requires restart)
+#wal_buffers = -1           # min 32kB, -1 sets based on shared_buffers
+                    # (change requires restart)
+#wal_writer_delay = 200ms       # 1-10000 milliseconds
+
+#commit_delay = 0           # range 0-100000, in microseconds
+#commit_siblings = 5            # range 1-1000
+
+# - Checkpoints -
+
+#checkpoint_segments = 3        # in logfile segments, min 1, 16MB each
+#checkpoint_timeout = 5min      # range 30s-1h
+#checkpoint_completion_target = 0.5 # checkpoint target duration, 0.0 - 1.0
+#checkpoint_warning = 30s       # 0 disables
+
+# - Archiving -
+
+#archive_mode = off     # allows archiving to be done
+                # (change requires restart)
+#archive_command = ''       # command to use to archive a logfile segment
+                # placeholders: %p = path of file to archive
+                #               %f = file name only
+                # e.g. 'test ! -f /mnt/server/archivedir/%f && cp %p /mnt/server/archivedir/%f'
+#archive_timeout = 0        # force a logfile segment switch after this
+                # number of seconds; 0 disables
+
+
+#------------------------------------------------------------------------------
+# REPLICATION
+#------------------------------------------------------------------------------
+
+# - Sending Server(s) -
+
+# Set these on the master and on any standby that will send replication data.
+
+#max_wal_senders = 0        # max number of walsender processes
+                # (change requires restart)
+#wal_keep_segments = 0      # in logfile segments, 16MB each; 0 disables
+#wal_sender_timeout = 60s   # in milliseconds; 0 disables
+
+#max_replication_slots = 0  # max number of replication slots
+                # (change requires restart)
+
+# - Master Server -
+
+# These settings are ignored on a standby server.
+
+#synchronous_standby_names = '' # standby servers that provide sync rep
+                # comma-separated list of application_name
+                # from standby(s); '*' = all
+#vacuum_defer_cleanup_age = 0   # number of xacts by which cleanup is delayed
+
+# - Standby Servers -
+
+# These settings are ignored on a master server.
+
+#hot_standby = off          # "on" allows queries during recovery
+                    # (change requires restart)
+#max_standby_archive_delay = 30s    # max delay before canceling queries
+                    # when reading WAL from archive;
+                    # -1 allows indefinite delay
+#max_standby_streaming_delay = 30s  # max delay before canceling queries
+                    # when reading streaming WAL;
+                    # -1 allows indefinite delay
+#wal_receiver_status_interval = 10s # send replies at least this often
+                    # 0 disables
+#hot_standby_feedback = off     # send info from standby to prevent
+                    # query conflicts
+#wal_receiver_timeout = 60s     # time that receiver waits for
+                    # communication from master
+                    # in milliseconds; 0 disables
+
+
+#------------------------------------------------------------------------------
+# QUERY TUNING
+#------------------------------------------------------------------------------
+
+# - Planner Method Configuration -
+
+#enable_bitmapscan = on
+#enable_hashagg = on
+#enable_hashjoin = on
+#enable_indexscan = on
+#enable_indexonlyscan = on
+#enable_material = on
+#enable_mergejoin = on
+#enable_nestloop = on
+#enable_seqscan = on
+#enable_sort = on
+#enable_tidscan = on
+
+# - Planner Cost Constants -
+
+#seq_page_cost = 1.0            # measured on an arbitrary scale
+#random_page_cost = 4.0         # same scale as above
+#cpu_tuple_cost = 0.01          # same scale as above
+#cpu_index_tuple_cost = 0.005       # same scale as above
+#cpu_operator_cost = 0.0025     # same scale as above
+#effective_cache_size = 4GB
+
+# - Genetic Query Optimizer -
+
+#geqo = on
+#geqo_threshold = 12
+#geqo_effort = 5            # range 1-10
+#geqo_pool_size = 0         # selects default based on effort
+#geqo_generations = 0           # selects default based on effort
+#geqo_selection_bias = 2.0      # range 1.5-2.0
+#geqo_seed = 0.0            # range 0.0-1.0
+
+# - Other Planner Options -
+
+#default_statistics_target = 100    # range 1-10000
+#constraint_exclusion = partition   # on, off, or partition
+#cursor_tuple_fraction = 0.1        # range 0.0-1.0
+#from_collapse_limit = 8
+#join_collapse_limit = 8        # 1 disables collapsing of explicit
+                    # JOIN clauses
+
+
+#------------------------------------------------------------------------------
+# ERROR REPORTING AND LOGGING
+#------------------------------------------------------------------------------
+
+# - Where to Log -
+
+#log_destination = 'stderr'     # Valid values are combinations of
+                    # stderr, csvlog, syslog, and eventlog,
+                    # depending on platform.  csvlog
+                    # requires logging_collector to be on.
+
+# This is used when logging to stderr:
+#logging_collector = off        # Enable capturing of stderr and csvlog
+                    # into log files. Required to be on for
+                    # csvlogs.
+                    # (change requires restart)
+
+# These are only used if logging_collector is on:
+#log_directory = 'pg_log'       # directory where log files are written,
+                    # can be absolute or relative to PGDATA
+#log_filename = 'postgresql-%Y-%m-%d_%H%M%S.log'    # log file name pattern,
+                    # can include strftime() escapes
+#log_file_mode = 0600           # creation mode for log files,
+                    # begin with 0 to use octal notation
+#log_truncate_on_rotation = off     # If on, an existing log file with the
+                    # same name as the new log file will be
+                    # truncated rather than appended to.
+                    # But such truncation only occurs on
+                    # time-driven rotation, not on restarts
+                    # or size-driven rotation.  Default is
+                    # off, meaning append to existing files
+                    # in all cases.
+#log_rotation_age = 1d          # Automatic rotation of logfiles will
+                    # happen after that time.  0 disables.
+#log_rotation_size = 10MB       # Automatic rotation of logfiles will
+                    # happen after that much log output.
+                    # 0 disables.
+
+# These are relevant when logging to syslog:
+#syslog_facility = 'LOCAL0'
+#syslog_ident = 'postgres'
+
+# This is only relevant when logging to eventlog (win32):
+#event_source = 'PostgreSQL'
+
+# - When to Log -
+
+#client_min_messages = notice       # values in order of decreasing detail:
+                    #   debug5
+                    #   debug4
+                    #   debug3
+                    #   debug2
+                    #   debug1
+                    #   log
+                    #   notice
+                    #   warning
+                    #   error
+
+#log_min_messages = warning     # values in order of decreasing detail:
+                    #   debug5
+                    #   debug4
+                    #   debug3
+                    #   debug2
+                    #   debug1
+                    #   info
+                    #   notice
+                    #   warning
+                    #   error
+                    #   log
+                    #   fatal
+                    #   panic
+
+#log_min_error_statement = error    # values in order of decreasing detail:
+                    #   debug5
+                    #   debug4
+                    #   debug3
+                    #   debug2
+                    #   debug1
+                    #   info
+                    #   notice
+                    #   warning
+                    #   error
+                    #   log
+                    #   fatal
+                    #   panic (effectively off)
+
+log_min_duration_statement = {{ postgresql_log_min_duration_statement }}
+                    # -1 is disabled, 0 logs all statements
+                    # and their durations, > 0 logs only
+                    # statements running at least this number
+                    # of milliseconds
+
+
+# - What to Log -
+
+#debug_print_parse = off
+#debug_print_rewritten = off
+#debug_print_plan = off
+#debug_pretty_print = on
+#log_checkpoints = off
+#log_connections = off
+#log_disconnections = off
+#log_duration = off
+#log_error_verbosity = default      # terse, default, or verbose messages
+#log_hostname = off
+log_line_prefix = '%t [%p-%l] %q%u@%d '         # special values:
+                    #   %a = application name
+                    #   %u = user name
+                    #   %d = database name
+                    #   %r = remote host and port
+                    #   %h = remote host
+                    #   %p = process ID
+                    #   %t = timestamp without milliseconds
+                    #   %m = timestamp with milliseconds
+                    #   %i = command tag
+                    #   %e = SQL state
+                    #   %c = session ID
+                    #   %l = session line number
+                    #   %s = session start timestamp
+                    #   %v = virtual transaction ID
+                    #   %x = transaction ID (0 if none)
+                    #   %q = stop here in non-session
+                    #        processes
+                    #   %% = '%'
+                    # e.g. '<%u%%%d> '
+#log_lock_waits = off           # log lock waits >= deadlock_timeout
+#log_statement = 'none'         # none, ddl, mod, all
+#log_temp_files = -1            # log temporary files equal or larger
+                    # than the specified size in kilobytes;
+                    # -1 disables, 0 logs all temp files
+log_timezone = 'UTC'
+
+
+#------------------------------------------------------------------------------
+# RUNTIME STATISTICS
+#------------------------------------------------------------------------------
+
+# - Query/Index Statistics Collector -
+
+#track_activities = on
+#track_counts = on
+#track_io_timing = off
+#track_functions = none         # none, pl, all
+#track_activity_query_size = 1024   # (change requires restart)
+#update_process_title = on
+stats_temp_directory = '/var/run/postgresql/{{ postgresql_version }}-main.pg_stat_tmp'
+
+
+# - Statistics Monitoring -
+
+#log_parser_stats = off
+#log_planner_stats = off
+#log_executor_stats = off
+#log_statement_stats = off
+
+
+#------------------------------------------------------------------------------
+# AUTOVACUUM PARAMETERS
+#------------------------------------------------------------------------------
+
+#autovacuum = on            # Enable autovacuum subprocess?  'on'
+                    # requires track_counts to also be on.
+log_autovacuum_min_duration = {{ postgresql_log_autovacuum_min_duration }}  # -1 disables, 0 logs all actions and
+                    # their durations, > 0 logs only
+                    # actions running at least this number
+                    # of milliseconds.
+#autovacuum_max_workers = 3     # max number of autovacuum subprocesses
+                    # (change requires restart)
+#autovacuum_naptime = 1min      # time between autovacuum runs
+#autovacuum_vacuum_threshold = 50   # min number of row updates before
+                    # vacuum
+#autovacuum_analyze_threshold = 50  # min number of row updates before
+                    # analyze
+#autovacuum_vacuum_scale_factor = 0.2   # fraction of table size before vacuum
+#autovacuum_analyze_scale_factor = 0.1  # fraction of table size before analyze
+#autovacuum_freeze_max_age = 200000000  # maximum XID age before forced vacuum
+                    # (change requires restart)
+#autovacuum_multixact_freeze_max_age = 400000000    # maximum multixact age
+                    # before forced vacuum
+                    # (change requires restart)
+#autovacuum_vacuum_cost_delay = 20ms    # default vacuum cost delay for
+                    # autovacuum, in milliseconds;
+                    # -1 means use vacuum_cost_delay
+#autovacuum_vacuum_cost_limit = -1  # default vacuum cost limit for
+                    # autovacuum, -1 means use
+                    # vacuum_cost_limit
+
+
+#------------------------------------------------------------------------------
+# CLIENT CONNECTION DEFAULTS
+#------------------------------------------------------------------------------
+
+# - Statement Behavior -
+
+#search_path = '"$user",public'     # schema names
+#default_tablespace = ''        # a tablespace name, '' uses the default
+#temp_tablespaces = ''          # a list of tablespace names, '' uses
+                    # only default tablespace
+#check_function_bodies = on
+#default_transaction_isolation = 'read committed'
+#default_transaction_read_only = off
+#default_transaction_deferrable = off
+#session_replication_role = 'origin'
+#statement_timeout = 0          # in milliseconds, 0 is disabled
+#lock_timeout = 0           # in milliseconds, 0 is disabled
+#vacuum_freeze_min_age = 50000000
+#vacuum_freeze_table_age = 150000000
+#vacuum_multixact_freeze_min_age = 5000000
+#vacuum_multixact_freeze_table_age = 150000000
+#bytea_output = 'hex'           # hex, escape
+#xmlbinary = 'base64'
+#xmloption = 'content'
+
+# - Locale and Formatting -
+
+datestyle = 'iso, mdy'
+#intervalstyle = 'postgres'
+timezone = 'UTC'
+#timezone_abbreviations = 'Default'     # Select the set of available time zone
+                    # abbreviations.  Currently, there are
+                    #   Default
+                    #   Australia (historical usage)
+                    #   India
+                    # You can create your own file in
+                    # share/timezonesets/.
+#extra_float_digits = 0         # min -15, max 3
+#client_encoding = sql_ascii        # actually, defaults to database
+                    # encoding
+
+# These settings are initialized by initdb, but they can be changed.
+lc_messages = 'en_US.UTF-8'         # locale for system error message
+                    # strings
+lc_monetary = 'en_US.UTF-8'         # locale for monetary formatting
+lc_numeric = 'en_US.UTF-8'          # locale for number formatting
+lc_time = 'en_US.UTF-8'             # locale for time formatting
+
+# default configuration for text search
+default_text_search_config = 'pg_catalog.english'
+
+# - Other Defaults -
+
+#dynamic_library_path = '$libdir'
+#local_preload_libraries = ''
+#session_preload_libraries = ''
+
+
+#------------------------------------------------------------------------------
+# LOCK MANAGEMENT
+#------------------------------------------------------------------------------
+
+#deadlock_timeout = 1s
+#max_locks_per_transaction = 64     # min 10
+                    # (change requires restart)
+# Note:  Each lock table slot uses ~270 bytes of shared memory, and there are
+# max_locks_per_transaction * (max_connections + max_prepared_transactions)
+# lock table slots.
+#max_pred_locks_per_transaction = 64    # min 10
+                    # (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# VERSION/PLATFORM COMPATIBILITY
+#------------------------------------------------------------------------------
+
+# - Previous PostgreSQL Versions -
+
+#array_nulls = on
+#backslash_quote = safe_encoding    # on, off, or safe_encoding
+#default_with_oids = off
+#escape_string_warning = on
+#lo_compat_privileges = off
+#quote_all_identifiers = off
+#sql_inheritance = on
+#standard_conforming_strings = on
+#synchronize_seqscans = on
+
+# - Other Platforms and Clients -
+
+#transform_null_equals = off
+
+
+#------------------------------------------------------------------------------
+# ERROR HANDLING
+#------------------------------------------------------------------------------
+
+#exit_on_error = off            # terminate session on any error?
+#restart_after_crash = on       # reinitialize after backend crash?
+
+
+#------------------------------------------------------------------------------
+# CONFIG FILE INCLUDES
+#------------------------------------------------------------------------------
+
+# These options allow settings to be loaded from files other than the
+# default postgresql.conf.
+
+#include_dir = 'conf.d'         # include files ending in '.conf' from
+                    # directory 'conf.d'
+#include_if_exists = 'exists.conf'  # include file only if it exists
+#include = 'special.conf'       # include file
+
+
+#------------------------------------------------------------------------------
+# CUSTOMIZED OPTIONS
+#------------------------------------------------------------------------------
+
+# Add settings for extensions here

--- a/ansible/roles/cartodb.postgresql/templates/postgresql.conf.j2
+++ b/ansible/roles/cartodb.postgresql/templates/postgresql.conf.j2
@@ -128,7 +128,6 @@ work_mem = {{ postgresql_work_mem }}                # min 64kB
 #maintenance_work_mem = 64MB        # min 1MB
 #autovacuum_work_mem = -1       # min 1MB, or -1 to use maintenance_work_mem
 #max_stack_depth = 2MB          # min 100kB
-{% if postgresql_version | version_compare('9.3', '>') %}
 dynamic_shared_memory_type = posix  # the default is the first option
                     # supported by the operating system:
                     #   posix
@@ -136,7 +135,6 @@ dynamic_shared_memory_type = posix  # the default is the first option
                     #   windows
                     #   mmap
                     # use none to disable dynamic shared memory
-{% endif %}
 
 # - Disk -
 

--- a/ansible/roles/cartodb.resque/defaults/main.yml
+++ b/ansible/roles/cartodb.resque/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 
 cartodb_resque_pid_dir: "{{ cartodb_dir }}/tmp/pids"
-cartodb_resque_workers: 2
+cartodb_resque_workers: 1


### PR DESCRIPTION
Updates the provisioner to properly setup the FDW configuration when using the `cartodb-org` fork of cartodb, when using the `ansible/group_vars/all.cartodb-org.example` group vars file instead of `all.example`. 
### To Test

Clone the cartodb-org fork to `../cartodb` and checkout the `bbg_production` branch. Then copy the `ansible/group_vars/all.cartodb-org.example` file to `ansible/group_vars/all`. Then run `vagrant up` and wait for the provisioner. Once it runs, you should be able to properly import FDW synced tables via the data library in the dashboard.

The existing `all.example` file will still work for the current master branch of hte upstream cartodb repository, and skips all of the local common data/FDW specific tasks.

I'm reprovisioning one more time on the `bbg_production` branch to verify this works as expected.
